### PR TITLE
indexUpdate: remove index from index bucket if len(indexValue) == 0

### DIFF
--- a/index.go
+++ b/index.go
@@ -82,6 +82,14 @@ func indexUpdate(typeName, indexName string, index Index, tx *bolt.Tx, key []byt
 		indexValue.add(key)
 	}
 
+	if len(indexValue) == 0 {
+		err := b.Delete(indexKey)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
 	iVal, err = encode(indexValue)
 	if err != nil {
 		return err


### PR DESCRIPTION
I think empty indexValues should be deleted to keep the index clean.


I have for example an index that maps categories to articles and if i delete all articles that belong to a category i get:
```
bolter -f kb.db -b _index:Article:Category
Bucket: _index:Article:Category
+----------------------------------------+-----------------------------------------------------------------------------------------------------------------------+
|                  KEY                   |                                                         VALUE                                                         |
+----------------------------------------+-----------------------------------------------------------------------------------------------------------------------+
|                                       |                                                                                                                      |
| 01B870NPNFZHNM83BA8VGB0B15            |                                                                                                                      |
| 01B8M37D74MCTYYBG954B7TN5R            |                                                                                                                      |
| 01B8MMGYM2X7KZ7N4AGEG5ZEE0            |                                                                                                                      |
| 01B98M4SMZRT8BN0NHESRABHMP            |                                                                                                                      |
| 01B9BNN74QHNSX8TC82HHPH5Q7            |                                                                                                                      |
| 01B9BW4NW4D8RC69KBNDVJWQHW            | 01B9BW6ZTEJ7BGE73KEXJFQMZB01B9C0N9M24FW5XQ5CK6QQRX6701B9K46JXEHPP3D0D5DPS3449R01B9K7FHXN3G2NHF3NPSQFPJ99 |
| 01B9GMWT1SGWC0SQPQF2W2AXK6            | 01B9GPPHG49CH8XW3QBW73AHN3                                                                                        |
| 01B9K2KQHCWGHB8VFVSPSP1YD3            | 01B9K24BBK0EFWHMA63EW02HMP01B9K2EKY2PN17BY8NEE454EX5                                                           |
| 01B9KE5CKESACHMDP5PYA2ZJJR            | 01B9KC8RN6EP4P9DXY0M4Q0PJZ01B9KCGPS010JW8E4NDSSCC20H01B9KD56K23S38TEAX8X4VXN5N                              |
| 01B9KE90SWSWBQ0PXJBEWTKR9J            | 01B9KE0WKB048RWS6127RHNGZR01B9KSPWSKMCPV2R3T4JWQA2VJ01B9KTVP2BYXMQD2VDXCD2S2AZ                              |
| cfeb78d5-2ff2-43b0-91d0-389eb1a7b1eb |                                                                                                                      |
+----------------------------------------+-----------------------------------------------------------------------------------------------------------------------+

```
