### PR TITLE
seekCursor bugfix: criterion value might not be in database

### DIFF
--- a/index.go
+++ b/index.go
@@ -298,7 +298,10 @@ func seekCursor(cursor *bolt.Cursor, criteria []*Criterion) (key, value []byte) 
 			return cursor.First()
 		}
 
-		return cursor.Seek(seek)
+		k, v := cursor.Seek(seek)
+		if k != nil {
+			return k, v
+		}
 	}
 
 	return cursor.First()


### PR DESCRIPTION
We found a bug when using the following query on our bolthold database and the value was not in the list of keys:
`bolthold.Where(bolthold.Key).Gt(value).Limit(max)`

When this is the case and > or the >= operator is used, the current code of `seekCursus` will seek the element in the database. I think this is an search optimization, since all keys are sorted. However, when the particular value is not in the database, no value is going to be found (logically of course). This results in the situation that no results are returned. However, there can still be items in the database that are greater than the given value. Now these results are not returned too.

My solution is to now always fall back on the First() function when the element cannot be found. This is of course a bit less efficient, but it solves the problem. If you wish to solve the problem more efficiently, we'd also be very happy. Then this pull request can be seen as an issue report.
